### PR TITLE
Add new switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ The screen is split into two parts, with the left and right part displaying the 
 On the top left and right are the source selectors, allowing you to select sources for the left and right video 
 respectively. You can either input a URL or open a local file. If the source is a HLS-playlist, you can also select which video stream you want to view.
 
+#### URL parameters
+
+If you want to programmatically change the sources or the playback position, you can use the following URL parameters:
+
+- `leftVideoUrl` – sets the left video source
+- `rightVideoUrl` – sets the right video source
+- `leftVideoVariant` – sets the left video HLS variant
+- `rightVideoVariant` – sets the right video HLS variant
+- `startPosition` – sets the start position in seconds
+
+To use the parameters, you have to URL-encode the source URL. For example, to load the videos `http://example.com/test1.mp4` and `http://example.com/test2.mp4`, open the following URL:
+
+```
+http://localhost:3000/?leftVideoUrl=http%3A%2F%2Fexample.com%2Ftest1.mp4&rightVideoUrl=http%3A%2F%2Fexample.com%2Ftest2.mp4
+```
+
 #### Shortcuts for video control
 
 <kbd>l</kbd> Play video  

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ If you want to programmatically change the sources or the playback position, you
 - `leftVideoVariant` – sets the left video HLS variant
 - `rightVideoVariant` – sets the right video HLS variant
 - `startPosition` – sets the start position in seconds
+- `hideHelp` – if 1, hides the automatic help menu
+- `hideSourceSelector` – if 1, hides the source selection menu
 
 To use the parameters, you have to URL-encode the source URL. For example, to load the videos `http://example.com/test1.mp4` and `http://example.com/test2.mp4`, open the following URL:
 

--- a/src/components/SourceSelector/index.js
+++ b/src/components/SourceSelector/index.js
@@ -13,7 +13,8 @@ class SourceSelector extends Component {
         this.urlInputKeyDown = this.urlInputKeyDown.bind(this);
         this.state = {
             source: this.props.defaultSource,
-            showUrlInput: false
+            showUrlInput: false,
+            visible: this.props.visible
         };
     }
 
@@ -182,7 +183,7 @@ class SourceSelector extends Component {
 
     render() {
         return (
-            <div className={"source-selector " + this.props.className}>
+            <div className={cx("source-selector", this.props.className, {'hidden': !this.props.visible})}>
                 <div className="source-buttons">
                     <div title="open URL" className="url-button" >
                         <FiGlobe style={{cursor: 'pointer'}} onClick={() => this.showUrlInput()}/>

--- a/src/components/VideoViewer/index.js
+++ b/src/components/VideoViewer/index.js
@@ -21,7 +21,8 @@ const rightVideoUrl = urlParams.get('rightVideoUrl') || leftVideoUrl;
 const leftVideoVariant = urlParams.get('leftVideoVariant') || 0;
 const rightVideoVariant = urlParams.get('rightVideoVariant') || 1;
 const startPosition = Number(urlParams.get('position')) || 0;
-
+const hideSourceSelector = Boolean(urlParams.get('hideSourceSelector'));
+const hideHelp = Boolean(urlParams.get('hideHelp'));
 
 const DEFAULT_SOURCE_LEFT = {
     type: 'url',
@@ -63,10 +64,12 @@ class VideoViewer extends Component {
             tracking: true,
             splitBorderVisible: true,
             rightVideoOffset: 0,
-            showHelp: true,
+            showHelp: !hideHelp,
+            showSourceSelector: !hideSourceSelector,
             playReverse: false,
             userDefinedPanZoom: false
         };
+        console.dir(this.state);
 
         this.onFullScreenChange = this.onFullScreenChange.bind(this);
     }
@@ -309,7 +312,8 @@ class VideoViewer extends Component {
                         </div>
                     </SplitView>
                     
-                    <VideoControls playing={this.state.playing}
+                    <VideoControls visible={this.state.showSourceSelector}
+                                   playing={this.state.playing}
                                    onPlay={() => this.playPause()}
                                    onStep={(n) => this.step(n)}
                                    onFullscreen={() => this.fullscreen()}
@@ -318,10 +322,12 @@ class VideoViewer extends Component {
                                    position={this.state.position}
                     />
 
-                    <SourceSelector className="left-source-selector"
+                    <SourceSelector visible={this.state.showSourceSelector}
+                                    className="left-source-selector"
                                     defaultSource={DEFAULT_SOURCE_LEFT}
                                     onChange={(value) => this.onLeftSourceChange(value)} />
-                    <SourceSelector className="right-source-selector"
+                    <SourceSelector visible={this.state.showSourceSelector}
+                                    className="right-source-selector"
                                     defaultSource={DEFAULT_SOURCE_RIGHT}
                                     onChange={(value) => this.onRightSourceChange(value)} />
                     <OffsetIndicator offset={this.state.rightVideoOffset}/>


### PR DESCRIPTION
Make it possible to hide the help menu when loading, and also hide the source selection bar.

This already includes the documentation commit from https://github.com/SVT/vivict/pull/6 (e5c5e98b3fbc1befdc1d2e9342f889e50d642393).